### PR TITLE
Implement Request Sending Functionality

### DIFF
--- a/lpf/src/components/UI/Card/GraphCard.js
+++ b/lpf/src/components/UI/Card/GraphCard.js
@@ -1,10 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import useHttp from '../../../hooks/useHttp'
 import Card from  './Card'
 import styles from './GraphCard.module.css'
 
 function GraphCard(props){
 
+    const { url } = props
     const [expanded, setExpanded] = useState(false)
+    const [skills, setSkills] = useState([])
+    const { isLoading, error, success, sendRequest } = useHttp()
+
+    function cleanSkills(data){
+        setSkills(data)
+    }
+
+    useEffect(() => {
+        sendRequest({endPoint: url}, cleanSkills)
+    }, [sendRequest, url])
 
     function clickHandler(){
         setExpanded((prevState) => {
@@ -14,8 +26,8 @@ function GraphCard(props){
 
     let content = <p>There are no skills to display at the moment</p>
 
-    if (props.skills){
-        content = props.skills.map((skill) => {
+    if (skills.length > 0){
+        content = skills.map((skill) => {
                     return (
                         <div className={styles['graph']} key={skill.name}>
                             <p>{skill.name} <i className={skill.icon}></i></p>
@@ -23,7 +35,7 @@ function GraphCard(props){
                                 <p className={`${styles['graph__labels__label']} ${styles['minimun']}`}>Novice</p>
                                 <p className={`${styles['graph__labels__label']} ${styles['maximum']}`}>Expert</p>
                             </div>
-                            <div className={styles['graph__bar']} style={{width: `${skill.expertise}%`}}></div>
+                            <div className={styles['graph__bar']} style={{width: `${skill.expertise_level}%`}}></div>
                         </div>
                     )
                 })
@@ -32,8 +44,10 @@ function GraphCard(props){
     return (
         <Card onClick={clickHandler} className={!expanded ? styles['graph-card'] : props.className}>
             <h2>{props.category}</h2>
-            {expanded && content}
-            <p>Click me to visualize/hide detailed information</p>
+            {expanded && !isLoading && !error && success && content}
+            {error && expanded &&  <p>{error}</p>}
+            {isLoading && expanded && <p>{`Loading ${props.category}...`}</p>}
+            {!expanded && <p>Click me to visualize/hide detailed information</p>}
         </Card>
     )
 }

--- a/lpf/src/components/UI/Card/GraphCard.js
+++ b/lpf/src/components/UI/Card/GraphCard.js
@@ -7,15 +7,10 @@ function GraphCard(props){
 
     const { url } = props
     const [expanded, setExpanded] = useState(false)
-    const [skills, setSkills] = useState([])
-    const { isLoading, error, success, sendRequest } = useHttp()
-
-    function cleanSkills(data){
-        setSkills(data)
-    }
+    const { isLoading, error, response, sendRequest } = useHttp()
 
     useEffect(() => {
-        sendRequest({endPoint: url}, cleanSkills)
+        sendRequest({endPoint: url})
     }, [sendRequest, url])
 
     function clickHandler(){
@@ -26,8 +21,8 @@ function GraphCard(props){
 
     let content = <p>There are no skills to display at the moment</p>
 
-    if (skills.length > 0){
-        content = skills.map((skill) => {
+    if (response.length > 0){
+        content = response.map((skill) => {
                     return (
                         <div className={styles['graph']} key={skill.name}>
                             <p>{skill.name} <i className={skill.icon}></i></p>
@@ -44,7 +39,7 @@ function GraphCard(props){
     return (
         <Card onClick={clickHandler} className={!expanded ? styles['graph-card'] : props.className}>
             <h2>{props.category}</h2>
-            {expanded && !isLoading && !error && success && content}
+            {expanded && !isLoading && !error && response && content}
             {error && expanded &&  <p>{error}</p>}
             {isLoading && expanded && <p>{`Loading ${props.category}...`}</p>}
             {!expanded && <p>Click me to visualize/hide detailed information</p>}

--- a/lpf/src/hooks/useHttp.js
+++ b/lpf/src/hooks/useHttp.js
@@ -3,31 +3,37 @@ const url = 'http://127.0.0.1:8000/main/'
 
 function useHttp(){
     const [isLoading, setIsLoading] = useState(false)
-    const [success, setSuccess] = useState(false)
     const [error, setError] = useState(false)
-    const sendRequest = useCallback(async (requestConfig, cleanUpProcess) => {
+    const [response, setResponse] = useState(false)
+    const sendRequest = useCallback(async (requestConfig, cleanUpProcess = () => {}) => {
         try{
             setIsLoading(true)
-            setSuccess(false)
-            setError(false)
+                        setError(false)
+            setResponse(false)
             const response = await fetch(url + requestConfig.endPoint,
                                         {method: requestConfig.method ? requestConfig.method : 'GET',
                                         headers: requestConfig.headers ? requestConfig.headers : {},
                                         body: requestConfig.content ? JSON.stringify(requestConfig.content) : null })
 
             const data = await response.json()
-            cleanUpProcess(data)
+
+            if (!response.ok){
+                const error = new Error()
+                error.error = data.error
+                throw error
+            }
+
+            setResponse(data)
         }catch(error){
-            setError(error.message)
+            setError(error)
         }
         setIsLoading(false)
-        setSuccess(true)
     }, [])
 
     return {
         isLoading,
-        success,
         error,
+        response,
         sendRequest
     }
 }

--- a/lpf/src/hooks/useHttp.js
+++ b/lpf/src/hooks/useHttp.js
@@ -1,0 +1,35 @@
+import { useState, useCallback } from 'react'
+const url = 'http://127.0.0.1:8000/main/'
+
+function useHttp(){
+    const [isLoading, setIsLoading] = useState(false)
+    const [success, setSuccess] = useState(false)
+    const [error, setError] = useState(false)
+    const sendRequest = useCallback(async (requestConfig, cleanUpProcess) => {
+        try{
+            setIsLoading(true)
+            setSuccess(false)
+            setError(false)
+            const response = await fetch(url + requestConfig.endPoint,
+                                        {method: requestConfig.method ? requestConfig.method : 'GET',
+                                        headers: requestConfig.headers ? requestConfig.headers : {},
+                                        body: requestConfig.content ? JSON.stringify(requestConfig.content) : null })
+
+            const data = await response.json()
+            cleanUpProcess(data)
+        }catch(error){
+            setError(error.message)
+        }
+        setIsLoading(false)
+        setSuccess(true)
+    }, [])
+
+    return {
+        isLoading,
+        success,
+        error,
+        sendRequest
+    }
+}
+
+export default useHttp

--- a/lpf/src/hooks/useHttp.js
+++ b/lpf/src/hooks/useHttp.js
@@ -5,7 +5,7 @@ function useHttp(){
     const [isLoading, setIsLoading] = useState(false)
     const [error, setError] = useState(false)
     const [response, setResponse] = useState(false)
-    const sendRequest = useCallback(async (requestConfig, cleanUpProcess = () => {}) => {
+    const sendRequest = useCallback(async (requestConfig) => {
         try{
             setIsLoading(true)
                         setError(false)

--- a/lpf/src/pages/Skills.js
+++ b/lpf/src/pages/Skills.js
@@ -4,26 +4,13 @@ import NextButton from '../components/UI/NextButton/NextButton'
 import GraphCard from '../components/UI/Card/GraphCard'
 import styles from './Skills.module.css'
 
-const categories = ['Speaking Languages', 'Tools and Technologies', 'Industry Knowledge']
-const skills = {
-    languages: [{name: 'Spanish', expertise: 100, icon: 'fab fa-python'}, {name: 'English', expertise: 75, icon: 'fab fa-python'}],
-    tools: [{toolType: 'Language', name: 'Python', expertise: 100, icon: 'fab fa-python'},
-            {toolType: 'Framework', name: 'Django', expertise: 75, icon: 'fab fa-python'},
-            {toolType: 'Language', name: 'Javascript', expertise: 75, icon: 'fab fa-python'},
-            {toolType: 'Library', name: 'React', expertise: 75, icon: 'fab fa-python'},
-            {toolType: 'Language', name: 'HTML/CSS', expertise: 100, icon: 'fab fa-python'},
-            {toolType: 'Library', name: 'D3.js', expertise: 25, icon: 'fab fa-python'},
-            ],
-    industryKnowledge: [{name: 'Web Development', expertise: 75, icon: 'fab fa-python'}]
-}
-
 function Skills(){
-    return (
+        return (
         <Fragment>
             <Board className={styles['skills-board']}>
-                <GraphCard category={categories[0]} className={styles['speaking-languages-card']} skills={skills.languages}/>
-                <GraphCard category={categories[1]} className={styles['tools-and-tech-card']} skills={skills.tools}/>
-                <GraphCard category={categories[2]} className={styles['industry-knowledge-card']} skills={skills.industryKnowledge}/>
+                <GraphCard category='Speaking Languages' className={styles['speaking-languages-card']} url='speaking_languages/'/>
+                <GraphCard category='Tools and Technologies' className={styles['tools-and-tech-card']} url='tools/'/>
+                <GraphCard category='Industry Knowledge' className={styles['industry-knowledge-card']} url='industry_knowledge/'/>
             </Board>
             <NextButton to='/certifications' activateClass='certifications' className={styles['next-button']}>Certifications</NextButton>
         </Fragment>


### PR DESCRIPTION
We implemented the request sending for information receiving and displaying in the front end, the ContactMe form is able to send emails and the skills page is already displaying skills. Now, as this is a really common pattern across all the application, we create a reusable piece of code that can be reused across components:
How did we do it?
- We created a configurable custom hook that is able to send requests to the backend